### PR TITLE
Extended to_function interface

### DIFF
--- a/+casos/+package/+core/@Polynomial/Polynomial.m
+++ b/+casos/+package/+core/@Polynomial/Polynomial.m
@@ -125,6 +125,9 @@ methods
     % public RedefinesParen interface
     p = cat(dim,varargin);
 
+    % convert to Casadi function
+    f = to_function(obj,variables,opts);
+
     function obj = reshape(obj,varargin)
         % Reshape polynomial matrix.
         assert(length(varargin{1}) <= 2, 'Size vector must not exceed two elements.')
@@ -177,13 +180,6 @@ methods
         assert(is_zerodegree(obj), 'Can only convert polynomial of degree zero.')
 
         M = full(reshape(obj.coeffs,size(obj)));
-    end
-
-    function f = to_function(obj,varargin)
-        % Return casadi.Function object using SX.
-        X = casadi.SX.sym('x',obj.nvars,1);
-        p = subs(obj,indeterminates(obj),casos.package.polynomial(X));
-        f = casadi.Function('f',num2cell(X),{casadi.SX(p)},str(obj.indeterminates),{'poly'},varargin{:});
     end
 
     %% Unary operators

--- a/+casos/+package/+core/@Polynomial/Polynomial.m
+++ b/+casos/+package/+core/@Polynomial/Polynomial.m
@@ -179,6 +179,13 @@ methods
         M = full(reshape(obj.coeffs,size(obj)));
     end
 
+    function f = to_function(obj,varargin)
+        % Return casadi.Function object using SX.
+        X = casadi.SX.sym('x',obj.nvars,1);
+        p = subs(obj,indeterminates(obj),casos.package.polynomial(X));
+        f = casadi.Function('f',num2cell(X),{casadi.SX(p)},str(obj.indeterminates),{'poly'},varargin{:});
+    end
+
     %% Unary operators
     function p = uplus(p)
         % Unary plus.

--- a/+casos/+package/+core/@Polynomial/to_function.m
+++ b/+casos/+package/+core/@Polynomial/to_function.m
@@ -1,0 +1,38 @@
+function f = to_function(obj,variables,opts)
+% Return casadi.Function object using SX.
+
+if (nargin < 2) || isstruct(variables)
+    % default variables
+    if (nargin > 1) 
+        % options given
+        opts = variables;
+    else
+        % default options
+        opts = struct;
+    end
+    variables = tuple2cell(obj.indeterminates);
+
+elseif (nargin < 3)
+    % default options
+    opts = struct;
+end
+
+% create symbolic variables
+in = cellfun(@to_symbolic, variables, 'UniformOutput', false);
+
+% substitute symbolic variables
+p = subs(obj,[variables{:}],casos.package.polynomial(vertcat(in{:})));
+
+f = casadi.Function('f',in,{casadi.SX(p)},opts);
+
+end
+
+function var = to_symbolic(x)
+% Convert indeterminate variable(s) into SX symbol.
+
+names = str(x);
+
+% use first character as name
+var = casadi.SX.sym(names{1}(1), length(x), 1);
+
+end

--- a/+casos/+package/+core/@Polynomial/to_function.m
+++ b/+casos/+package/+core/@Polynomial/to_function.m
@@ -24,21 +24,29 @@ elseif (nargin < 3)
 end
 
 % create symbolic variables
-in = cellfun(@to_symbolic, variables, 'UniformOutput', false);
+[in,names] = cellfun(@to_symbolic, variables, 'UniformOutput', false);
 
 % substitute symbolic variables
 p = subs(obj,[variables{:}],casos.package.polynomial(vertcat(in{:})));
 
-f = casadi.Function('f',in,{casadi.SX(p)},opts);
+f = casadi.Function('f',in,{casadi.SX(p)},names,{'poly'},opts);
 
 end
 
-function var = to_symbolic(x)
+function [var,dstr] = to_symbolic(x)
 % Convert indeterminate variable(s) into SX symbol.
 
-names = str(x);
+varnames = str(x);
+
+if isscalar(varnames)
+    % use variable name
+    dstr = varnames{1};
+else
+    % use first character
+    dstr = varnames{1}(1);
+end
 
 % use first character as name
-var = casadi.SX.sym(names{1}(1), length(x), 1);
+var = casadi.SX.sym(dstr, length(x), 1);
 
 end

--- a/+casos/+package/+core/@Polynomial/to_function.m
+++ b/+casos/+package/+core/@Polynomial/to_function.m
@@ -1,3 +1,9 @@
+% SPDX-FileCopyrightText: 2026 Institute of Flight Mechanics and Controls, University of Stuttgart
+% SPDX-FileCopyrightText: Author(s): Torbjørn Cunis <tcunis@ifr.uni-stuttgart.de>
+% SPDX-FileContributor: For a full list of contributors, see <https://github.com/ifr-ofc/casos>
+%
+% SPDX-License-Identifier: GPL-3.0-only
+
 function f = to_function(obj,variables,opts)
 % Return casadi.Function object using SX.
 

--- a/+casos/+package/+core/GenericPolynomial.m
+++ b/+casos/+package/+core/GenericPolynomial.m
@@ -153,29 +153,14 @@ methods
     end
 
     %% Conversion
-    function v = casos.Indeterminates(obj) %#ok<STOUT,MANU>
+    function v = casos.Indeterminates(obj) %#ok<MANU,STOUT>
         % Convert to indeterminates.
         error('Notify the developers.')
     end
 
-    function f = to_sxfunction(obj,varargin)
-        % Return casadi.Function object using SX.
-        X = casadi.SX.sym('x',obj.nvars,1);
-        p = subs(obj,indeterminates(obj),casos.package.polynomial(X));
-        f = casadi.Function('f',num2cell(X),{casadi.SX(p)},str(obj.indeterminates),{'poly'},varargin{:});
-    end
-
-    function f = to_mxfunction(obj,varargin)
-        % Return casadi.Function object using MX.
-        X = casadi.MX.sym('x',obj.nvars,1);
-        p = subs(obj,indeterminates(obj),casos.package.polynomial(X));
-        f = casadi.Function('f',num2cell(X),{casadi.MX(p)},str(obj.indeterminates),{'poly'},varargin{:});
-    end
-
-    function f = to_function(obj,varargin)
+    function f = to_function(obj,varargin) %#ok<STOUT,INUSD>
         % Return casadi.Function object.
-        % Overload for default behaviour.
-        f = to_sxfunction(obj,varargin{:});
+        error('Notify the developers.');
     end
 
     %% Concatenation

--- a/+casos/@Indeterminates/Indeterminates.m
+++ b/+casos/@Indeterminates/Indeterminates.m
@@ -173,9 +173,16 @@ methods
         % Return sum of variables.
         z = sum(casos.package.polynomial(obj));
     end
+
     function obj = transpose(obj)
         % Toggle transpose flag.
         obj.transp = ~obj.transp;
+    end
+
+    % Convert to cell of single variables
+    function cell_of_indets = tuple2cell(obj)
+        % Return a cell array of individual indeterminate variables.
+        cell_of_indets = cellfun(@(var) casos.Indeterminates(var), obj.variables, 'UniformOutput', false);
     end
 
     % Display
@@ -196,12 +203,6 @@ methods (Access=protected)
     obj = parenAssign(obj,idx,varargin);
     obj = parenDelete(obj,idx);
     varargout = parenReference(obj,index);
-
-    % Convert to cell of single variables
-    function cell_of_indets = tuple2cell(obj)
-        % Return a cell array of individual indeterminate variables.
-        cell_of_indets = cellfun(@(var) casos.Indeterminates(var), obj.variables, 'UniformOutput', false);
-    end
 end
 
 methods (Access={?casos.package.core.PolynomialInterface})


### PR DESCRIPTION
The current `to_function` interface is extended to allow for the following syntax:

```matlab
f = to_function(p, {u w x}, opts);
```
creating a function with vector arguments $u$, $w$, and $x$. The previous syntax is recovered using conversion from tuples of indeterminate variables to cells of indeterminate variables. Use of `to_function` without second argument will be retired at some point.

This PR replaces #166. See #165 for further discussions.